### PR TITLE
Error en la clase Controladora.java

### DIFF
--- a/src/main/java/icesi/vip/alien/alien/ruteo/Controladora.java
+++ b/src/main/java/icesi/vip/alien/alien/ruteo/Controladora.java
@@ -401,4 +401,4 @@ public class Controladora {
 		m.setNodos(nodos);
 	}*/
 	
-
+}


### PR DESCRIPTION
Ya solucioné el problema con la clase Controladora.java de nuestro modulo de ruteo, efectivamente era un corchete faltante.